### PR TITLE
Updated script URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,14 @@ Add the following `script` tag to your `index.html`:
 
 ```html
 <!-- Latest -->
-<script src="https://unpkg.com/docsify-copy-code/index.js"></script>
+<script src="https://unpkg.com/docsify-copy-code"></script>
+```
+
+If you prefer to load a specific version, include a version number in the URL:
+
+```html
+<!-- Latest v2.x.x -->
+<script src="https://unpkg.com/docsify-copy-code@2"></script>
 ```
 
 That is it! If all went well, any preformatted code should now have a `Click to copy!` link on hover.
-


### PR DESCRIPTION
Just tested 2.x. The code changes work as expected, however...

The previous instructions explicitly linked to the `index.js`:

```html
<script src="//unpkg.com/docsify-copy-code/index.js"></script>
```

Since the index was moved to `/src`, this file no longer exists. The correct URL--which lets unpkg.com redirect based on the `unpkg` values in `package.json`--is actually:

```html
<!-- Let unpkg redirect, based on "unpkg" value in package.json -->
<script src="//unpkg.com/docsify-copy-code"></script>
```

I didn't realize that the previous instructions linked directly to `index.js`, so I apologize for the oversight 🤦‍♂️ . Happy to help mitigate this if necessary.

In the meantime, I've updated the README to link to the correct URL *and* provided a version-specific URL.

Thanks @jperasmus.