### PR TITLE
Patch for v1 installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,24 @@ A docsify plugin that adds a button to easily copy code blocks to your clipboard
 
 Assuming you have a working [docsify](https://docsify.js.org) app set up, it is easy to use this plugin.
 
-Add the following `script` tag to your `index.html`:
+#### Production
 
-```html
-<!-- Latest -->
-<script src="https://unpkg.com/docsify-copy-code"></script>
-```
-
-If you prefer to load a specific version, include a version number in the URL:
+Add the following script tag to your `index.html`:
 
 ```html
 <!-- Latest v2.x.x -->
 <script src="https://unpkg.com/docsify-copy-code@2"></script>
+```
+
+This will load the latest v2.x of the plugin. Specifying the version ensures that the release of a major update (v3.x) will not break your production site.
+
+#### Development
+
+If you prefer to load the latest version of the library, you may do so my omitting the `@[version]` from the above URL:
+
+```html
+<!-- Latest (not recommended for production) -->
+<script src="https://unpkg.com/docsify-copy-code"></script>
 ```
 
 That is it! If all went well, any preformatted code should now have a `Click to copy!` link on hover.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,14 @@
+// Fix for v1.x installations
+(function() {
+    // Deprecation warning for v1.x: init()
+    window.DocsifyCopyCodePlugin = {
+        init: function() {
+            return function(hook, vm) {
+                hook.ready(function() {
+                    // eslint-disable-next-line
+                    console.warn('[Update] docsify-copy-code has been updated. Please see new installation instructions at https://github.com/jperasmus/docsify-copy-code.');
+                });
+            };
+        }
+    };
+})();


### PR DESCRIPTION
- Recommend version-specific CDN URL over latest
- Add placeholder index.js in v1 location with console message indicating an update is available. This will prevent old v1 installations from breaking.