### PR TITLE
autohide copy-code button after copy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,6 +97,9 @@ function docsifyCopyCode(hook, vm) {
             }, 1000);
           }
 
+          // unfocus clicked element
+          setTimeout(() => { evt.target.blur(); }, 1500);
+
           selection = window.getSelection();
 
           if (selection) {


### PR DESCRIPTION
Small change but helps keep me sane. 😅 
![autohide-after-copy](https://github.com/user-attachments/assets/a0139961-e3b6-4f1f-b531-8a802bf082d0)